### PR TITLE
Weird typo / error

### DIFF
--- a/docs/lpic2.210.2.md
+++ b/docs/lpic2.210.2.md
@@ -61,8 +61,7 @@ session
     both an opening and closing hook for modules that affect the
     services available to a user.
 
-PAM can be configured using the file `/etc/pam.conf` ConfiguringPAM
-PAMpam.conf which has the following format:
+PAM can be configured using the file `/etc/pam.conf` which has the following format:
 
         service   type   control   module-path   module-arguments
                 


### PR DESCRIPTION
PAM can be configured using the file `/etc/pam.conf` ConfiguringPAM PAMpam.conf which has the following format: --> PAM can be configured using the file `/etc/pam.conf` which has the following format:

Love the book btw