### PR TITLE
"Icinga2" Update

### DIFF
--- a/docs/lpic2.200.2.md
+++ b/docs/lpic2.200.2.md
@@ -53,7 +53,7 @@ collectd only collects data, to display the collected data addtional
 tools are required.
 
 Also other monitoring tools like
-[Icanga2](https://www.icinga.org/products/icinga-2/),
+[Icinga2](https://www.icinga.com/products/infrastructure_monitoring/),
 [Nagios](http://www.nagios.org), [MRTG](http://oss.oetiker.ch/mrtg/) and
 [Cacti](http://www.cacti.net) can be used to measure, collect and
 display resource performance statistics. Using a montoring tool can help


### PR DESCRIPTION
The "Icinga2" product is spelled with an 'i', rather than an 'a'. The previous URL used for Icinga2 is also no longer active, but the one I provided is.