### PR TITLE
Format a whole command line

### DIFF
--- a/docs/lpic2.204.1.md
+++ b/docs/lpic2.204.1.md
@@ -350,7 +350,7 @@ format a RAID drive:
     on the array simply by `diff`'ing the current and stored output.
     Create as follows:
 
-    `mdadm` \--detail \--scan \--verbose \> `/etc/mdadm.conf`
+        mdadm --detail --scan --verbose > /etc/mdadm.conf
 
 5.  Create mount points and edit `/etc/fstab`
 


### PR DESCRIPTION
A partial monospaced command line
is now a completely monospaced command line.

Indenting 8 spaces is also done in file lpic2.204.2.md.