### PR TITLE
Fix authconfig command in lpic2.210.2.md

### DIFF
--- a/docs/lpic2.210.2.md
+++ b/docs/lpic2.210.2.md
@@ -371,7 +371,7 @@ Use your package manager to install these packages.
 
 2\. Check the current settings for sssd, if any:
 
-        # authconfig test
+        # authconfig --test
                 
 
 This will show you the current settings which are already in place. Also


### PR DESCRIPTION


`authconfig` only accepts `--test` action.
```shell
# authconfig test
authconfig: unexpected argument
```