### PR TITLE
Fix missing md title syntax in lpic2.200.1.md

### DIFF
--- a/docs/lpic2.200.1.md
+++ b/docs/lpic2.200.1.md
@@ -678,7 +678,7 @@ Some of the most important options to be used with `sar` are:
 
 -   `-r` Free memory and swap over time
 
-Match / correlate system symptoms with likely problems
+## Match / correlate system symptoms with likely problems
 
 
 To troubleshoot a given problem, one must first be able to distinguish


### PR DESCRIPTION
highlight a section header