### PR TITLE
Update lpic2.201.3.md 0 - removed inconsistent line 126

### DIFF
--- a/docs/lpic2.201.3.md
+++ b/docs/lpic2.201.3.md
@@ -123,7 +123,6 @@ card. To verify that this specific module exists, in this case
 `sym53c8xx.ko` exists, look for the file `sym53c8xx.ko` in the
 `/lib/modules/kernel-version/kernel/drivers/scsi/` directory:
 
-unresolved symbol
 
         # insmod sym53c8xx.ko
         # echo $?


### PR DESCRIPTION
removed inconsistent line 126 "unresolved symbol" does not cause an issue with the flow of the document as not relavant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated "unresolved symbol" line from the documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->